### PR TITLE
Box Style Referencing Path For Nonexistant Image 

### DIFF
--- a/src/component/Box.css
+++ b/src/component/Box.css
@@ -1,7 +1,5 @@
 
 .box
  {
-    background-image: url("/Users/karvangum/projects/weatherapp/src/images/Background.jpg") no-repeat center center;
-
     padding: 25px 400px 50px 550px;
 }


### PR DESCRIPTION
# Background

Fix for [this](https://github.com/Priyami/weatherapp/issues/5) issue.

# Updates

* Remove style for asset that did not exist on local machine
  * The element that was being targeted already had background-image set in CSS, and thus, it was not needed

# Files Of Interest

* `Box.css`